### PR TITLE
OptiConjGrad set_b method : also set CostLinear b to new value.

### DIFF
--- a/Opti/OptiConjGrad.m
+++ b/Opti/OptiConjGrad.m
@@ -55,6 +55,7 @@ classdef OptiConjGrad < Opti
             assert(checkSize(b,this.A.sizeout),'A sizeout and size of b must be equal');
             this.b=b;
             this.cost.y=b;
+            this.cost.mapsCell{2}.y=b;
         end
         function initialize(this,x0)
             % Reimplementation from :class:`Opti`.


### PR DESCRIPTION
Hello,

I would like to propose a minor change in the `OptiConjGrad`'s `set_b` method.

The current `set_b` method of `OptiConjGrad` doesn't update the `y` property of the `CostLinear` corresponding to `b^T x`. I suggest to add `this.cost.mapsCell{2}.y=b;` to also change its value.

This change doesn't affect the output of the algorithm as the `initialize` method uses `this.b` which is updated in `set_b`.  It only affects the cost computed by the `OutputOpti`.