### PR TITLE
Implement deep copy for Map and inherited classes

### DIFF
--- a/Abstract/Cost.m
+++ b/Abstract/Cost.m
@@ -225,4 +225,14 @@ classdef Cost < Map
             this.y=y;
         end
     end
+    
+    methods (Access = protected)
+        %% Copy
+        function this = copyElement(obj)
+            this = copyElement@Map(obj);
+            this.memoCache.applyGrad=struct('in', [], 'out', []);
+            this.memoCache.applyProx=struct('in', [], 'out', []);
+            this.memoCache.applyProxFench=struct('in', [], 'out', []);
+        end
+    end  
 end

--- a/Abstract/LinOp.m
+++ b/Abstract/LinOp.m
@@ -305,6 +305,15 @@ classdef LinOp < Map
             x = this.applyAdjoint(y);
         end
     end
-    
+    methods (Access = protected)
+         %% Copy
+         function this = copyElement(obj)
+             this = copyElement@Map(obj);
+             this.memoCache.applyAdjointInverse=struct('in', [], 'out', []);
+             this.memoCache.applyAdjoint=struct('in', [], 'out', []);
+             this.memoCache.applyHtH=struct('in', [], 'out', []);
+             this.memoCache.applyHHt=struct('in', [], 'out', []);
+      end
+    end  
 end
 

--- a/Abstract/Map.m
+++ b/Abstract/Map.m
@@ -421,13 +421,16 @@ classdef (Abstract) Map < matlab.mixin.Copyable
                 x = this.memoCache.(fieldName).out;
             end
         end
-        %% Copy
-      function this = copyElement(obj)
-          this = copyElement@matlab.mixin.Copyable(obj);
-          this.memoCache = struct('apply', struct('in', [], 'out', []),...
-              'applyJacobianT', struct('in', [], 'out', []), ...
-              'applyInverse', struct('in', [], 'out', []));
-          this.precomputeCache = struct();
-      end
+        %% Deep Copy
+        function this = copyElement(obj)
+            % Perform a deep copy of \\(\\mathrm{H}\\) 
+            %
+            % Called by the function :meth:`copy`
+            this = copyElement@matlab.mixin.Copyable(obj);
+            this.memoCache = struct('apply', struct('in', [], 'out', []),...
+                'applyJacobianT', struct('in', [], 'out', []), ...
+                'applyInverse', struct('in', [], 'out', []));
+            this.precomputeCache = struct();
+        end
     end
 end

--- a/Abstract/Map.m
+++ b/Abstract/Map.m
@@ -1,4 +1,4 @@
-classdef (Abstract) Map < handle
+classdef (Abstract) Map < matlab.mixin.Copyable
     % Abstract class for Maps which maps elements from \\(\\mathrm{X}\\) to
     % \\(\\mathrm{Y}\\)
     % $$ \\mathrm{H}: \\mathrm{X}\\rightarrow \\mathrm{Y}.$$
@@ -421,5 +421,13 @@ classdef (Abstract) Map < handle
                 x = this.memoCache.(fieldName).out;
             end
         end
+        %% Copy
+      function this = copyElement(obj)
+          this = copyElement@matlab.mixin.Copyable(obj);
+          this.memoCache = struct('apply', struct('in', [], 'out', []),...
+              'applyJacobianT', struct('in', [], 'out', []), ...
+              'applyInverse', struct('in', [], 'out', []));
+          this.precomputeCache = struct();
+      end
     end
 end

--- a/Abstract/OperationsOnMaps/CostComposition.m
+++ b/Abstract/OperationsOnMaps/CostComposition.m
@@ -114,4 +114,14 @@ classdef CostComposition < MapComposition & Cost
             this.y=y;
         end
     end
+    
+    methods (Access = protected)
+         %% Copy
+         function this = copyElement(obj)
+             this = copyElement@MapComposition(obj);
+            this.memoCache.applyGrad=struct('in', [], 'out', []);
+            this.memoCache.applyProx=struct('in', [], 'out', []);
+            this.memoCache.applyProxFench=struct('in', [], 'out', []);
+      end
+    end  
 end

--- a/Abstract/OperationsOnMaps/CostMultiplication.m
+++ b/Abstract/OperationsOnMaps/CostMultiplication.m
@@ -103,5 +103,14 @@ classdef CostMultiplication < Cost
                 M=makeComposition_@Cost(this,G);
             end
         end
+     end
+    
+    methods (Access = protected)
+         %% Copy
+         function this = copyElement(obj)
+             this = copyElement@Cost(obj);
+            this.cost1 = copy(obj.cost1);
+            this.cost2 =  copy(obj.cost1);
+      end
     end
 end

--- a/Abstract/OperationsOnMaps/CostSummation.m
+++ b/Abstract/OperationsOnMaps/CostSummation.m
@@ -98,4 +98,13 @@ classdef CostSummation <  MapSummation & Cost
             M=makeComposition_@MapSummation(this,G);
         end
     end
+    methods (Access = protected)
+         %% Copy
+         function this = copyElement(obj)
+             this = copyElement@MapSummation(obj);
+            this.memoCache.applyGrad=struct('in', [], 'out', []);
+            this.memoCache.applyProx=struct('in', [], 'out', []);
+            this.memoCache.applyProxFench=struct('in', [], 'out', []);
+      end
+    end  
 end

--- a/Abstract/OperationsOnMaps/LinOpAdjoint.m
+++ b/Abstract/OperationsOnMaps/LinOpAdjoint.m
@@ -91,5 +91,13 @@ classdef LinOpAdjoint < LinOp
             M=this.TLinOp.makeHHt();
         end
     end
+    
+    methods (Access = protected)
+        %% Copy
+        function this = copyElement(obj)
+            this = copyElement@LinOp(obj);
+            this.TLinOp = copyElement@LinOp(obj.TLinOp);
+        end
+    end
 end
 

--- a/Abstract/OperationsOnMaps/LinOpComposition.m
+++ b/Abstract/OperationsOnMaps/LinOpComposition.m
@@ -123,5 +123,16 @@ classdef LinOpComposition < MapComposition & LinOp
             end
         end
     end
+    
+    methods (Access = protected)
+         %% Copy
+         function this = copyElement(obj)
+             this = copyElement@MapComposition(obj);
+             this.memoCache.applyAdjointInverse=struct('in', [], 'out', []);
+             this.memoCache.applyAdjoint=struct('in', [], 'out', []);
+             this.memoCache.applyHtH=struct('in', [], 'out', []);
+             this.memoCache.applyHHt=struct('in', [], 'out', []);
+      end
+    end  
 end
 

--- a/Abstract/OperationsOnMaps/LinOpSummation.m
+++ b/Abstract/OperationsOnMaps/LinOpSummation.m
@@ -97,5 +97,16 @@ classdef LinOpSummation < MapSummation &  LinOp
             end
         end
     end
+    
+    methods (Access = protected)
+        %% Copy
+      function this = copyElement(obj)
+          this = copyElement@MapSummation(obj);
+          this.memoCache.applyAdjointInverse=struct('in', [], 'out', []);
+          this.memoCache.applyAdjoint=struct('in', [], 'out', []);
+          this.memoCache.applyHtH=struct('in', [], 'out', []);
+          this.memoCache.applyHHt=struct('in', [], 'out', []);
+      end
+    end
 end
 

--- a/Abstract/OperationsOnMaps/MapComposition.m
+++ b/Abstract/OperationsOnMaps/MapComposition.m
@@ -89,4 +89,13 @@ classdef MapComposition < Map
 			 end
         end
     end	
+    
+    methods (Access = protected)
+        %% Copy
+      function this = copyElement(obj)
+          this = copyElement@Map(obj);
+          this.H1 = copyElement@Map(obj.H1);
+          this.H2 = copyElement@Map(obj.H2);
+      end
+    end
 end

--- a/Abstract/OperationsOnMaps/MapInversion.m
+++ b/Abstract/OperationsOnMaps/MapInversion.m
@@ -73,5 +73,13 @@ classdef MapInversion < Map
             end
         end
     end
+      
+    methods (Access = protected)
+        %% Copy
+      function this = copyElement(obj)
+          this = copyElement@Map(obj);
+          this.M = copy(obj.M);
+      end
+    end
 end
 

--- a/Abstract/OperationsOnMaps/MapMultiplication.m
+++ b/Abstract/OperationsOnMaps/MapMultiplication.m
@@ -64,5 +64,14 @@ classdef MapMultiplication < Map
             M=MapMultiplication(this.M1*G,this.M2*G);
         end
     end
+    
+    
+    methods (Access = protected)
+        %% Copy
+      function this = copyElement(obj)
+          this = copyElement@Map(obj);
+          this.M1 = copyElement@Map(obj.M1);
+          this.M2 = copyElement@Map(obj.M2);
+      end
 end
 

--- a/Abstract/OperationsOnMaps/MapSummation.m
+++ b/Abstract/OperationsOnMaps/MapSummation.m
@@ -113,5 +113,15 @@ classdef MapSummation < Map
             end
         end
     end
+    
+    methods (Access = protected)
+        %% Copy
+      function this = copyElement(obj)
+          this = copyElement@Map(obj);
+            for n = 1:this.numMaps
+                 this.mapsCell{n} = copy(obj.mapsCell{n});
+            end
+      end
+    end
 end
 

--- a/Abstract/OperationsOnMaps/OneToMany.m
+++ b/Abstract/OperationsOnMaps/OneToMany.m
@@ -101,5 +101,14 @@ classdef OneToMany < LinOp
             end
         end
     end
+    methods (Access = protected)
+        %% Copy
+      function this = copyElement(obj)
+          this = copyElement@LinOp(obj);
+            for n = 1:this.numLinOp
+                 this.ALinOp{n} = copy(obj.ALinOp{n});
+            end
+      end
+    end
 end
 

--- a/Abstract/OperationsOnMaps/StackLinOp.m
+++ b/Abstract/OperationsOnMaps/StackLinOp.m
@@ -118,5 +118,15 @@ classdef StackLinOp < LinOp
             end
         end
     end
+    
+    methods (Access = protected)
+        %% Copy
+      function this = copyElement(obj)
+          this = copyElement@LinOp(obj);
+            for n = 1:this.numLinOp
+                 this.ALinOp{n} = copy(obj.ALinOp{n});
+            end
+      end
+    end
 end
 

--- a/Abstract/OperationsOnMaps/StackMap.m
+++ b/Abstract/OperationsOnMaps/StackMap.m
@@ -112,5 +112,15 @@ classdef StackMap < Map
             M = StackMap(M,this.alpha);
         end
     end
+    
+    methods (Access = protected)
+        %% Copy
+      function this = copyElement(obj)
+          this = copyElement@Map(obj);
+            for n = 1:this.numMaps
+                 this.mapsCell{n} = copy(obj.mapsCell{n});
+            end
+      end
+    end
 end
 

--- a/Cost/CostGoodRoughness.m
+++ b/Cost/CostGoodRoughness.m
@@ -38,7 +38,7 @@ classdef CostGoodRoughness < Cost
     properties 
         bet; % smoothing parameter
     end
-    % Protected Set and protected Read propersumOpties
+    % Protected Set properties
     properties (SetAccess = protected,GetAccess = public)
         G;        % gradient operators
         sumOp;

--- a/Cost/CostGoodRoughness.m
+++ b/Cost/CostGoodRoughness.m
@@ -38,7 +38,7 @@ classdef CostGoodRoughness < Cost
     properties 
         bet; % smoothing parameter
     end
-    % Protected Set and protected Read properties
+    % Protected Set and protected Read propersumOpties
     properties (SetAccess = protected,GetAccess = public)
         G;        % gradient operators
         sumOp;
@@ -90,4 +90,13 @@ classdef CostGoodRoughness < Cost
             dem=abs(x).^2 + this.bet;                % squared denominator gdem=dem.^(-3/2)
         end
     end
+    
+    methods (Access = protected)
+         %% Copy
+         function this = copyElement(obj)
+             this = copyElement@Cost(obj);
+             this.G = copy(obj.G);
+            this.sumOp = copy(obj.sumOp);          
+      end
+    end  
 end

--- a/Cost/CostHyperBolic.m
+++ b/Cost/CostHyperBolic.m
@@ -101,4 +101,12 @@ classdef CostHyperBolic < Cost
             F = sqrt(this.sumOp*u + this.epsilon.^2);
         end
     end
+    
+    methods (Access = protected)
+         %% Copy
+         function this = copyElement(obj)
+             this = copyElement@Cost(obj);
+             this.sumOp = copy(obj.sumOp);
+      end
+    end  
 end

--- a/Cost/CostL2.m
+++ b/Cost/CostL2.m
@@ -107,4 +107,12 @@ classdef CostL2 < Cost
             M = CostL2Composition(this,G);
         end
     end
+    
+    methods (Access = protected)
+         %% Copy
+         function this = copyElement(obj)
+             this = copyElement@Cost(obj);
+             this.W = copy(obj.W);          
+      end
+    end  
 end

--- a/Cost/CostL2Composition.m
+++ b/Cost/CostL2Composition.m
@@ -34,7 +34,6 @@ classdef CostL2Composition <  CostComposition
         OpSumP;       % Operator used to compute the prox when H2 is the combination of a LinOpDownsample with a LinOpConv
         Lamb;         % Operator used to compute the prox when H2 is the combination of a LinOpSum with a LinOpConv
         H2H2t;        % operator used for prox computation
-        Id;           % an identity operator used with Woodbury Formula
         doWoodbury=0; % to correctly switch in the prox
         doSumConv=0;  % to correctly switch in the prox
         doDownConv=0; % to correctly switch in the prox
@@ -62,10 +61,9 @@ classdef CostL2Composition <  CostComposition
                 this.doSumConv=1;
             % If H2*H2' +Id is invertible --> use Woodbury formulae
             elseif isa(this.H2,'LinOpComposition') && isnumeric(this.H1.W) && this.H1.W==1
-                T=this.H2*this.H2'+ LinOpIdentity(this.H2.sizeout);
+                T=this.H2*this.H2'+ 1;
                 if T.isInvertible
                     this.H2H2t=this.H2*this.H2';
-                    this.Id=LinOpIdentity(this.H2.sizeout);
                     this.doWoodbury=1;
                 end
             end
@@ -194,7 +192,7 @@ classdef CostL2Composition <  CostComposition
                 else
                     tmp=alpha*this.H2.applyAdjoint(this.H1.W*this.H1.y)+x;                   
                 end
-                y=tmp - this.H2'*(this.H2H2t + 1/alpha*this.Id)^(-1)*this.H2*tmp;
+                y=tmp - this.H2'*(this.H2H2t + 1/alpha)^(-1)*this.H2*tmp;
             % Default implementation
             elseif this.isH2LinOp && ~this.isH2SemiOrtho
                 % TODO : reimplement similarly to the above Woodbury

--- a/Cost/CostL2Composition.m
+++ b/Cost/CostL2Composition.m
@@ -244,4 +244,15 @@ classdef CostL2Composition <  CostComposition
             end
         end
     end
+    
+    methods (Access = protected)
+         %% Copy
+         function this = copyElement(obj)
+             this = copyElement@CostComposition(obj);
+             this.OpSumP = copy(obj.OpSumP);
+             this.Lamb = copy(obj.Lamb);
+             this.H2H2t = copy(obj.H2H2t);
+      end
+    end  
+    
 end

--- a/Cost/TemplateCost.m
+++ b/Cost/TemplateCost.m
@@ -79,5 +79,12 @@ classdef TemplateCost < Cost
         
         % TODO : IMPLEMENT ANY USEFUL METHOD FROM INHERITED FROM MAP OR
         % COST CLASSES
+        
+        %% Deep copy: IMPLEMENT IF APPLICABLE
+        function this = copyElement(obj)
+            this = copyElement@Cost(obj);
+            % properties that are handle objects such as Map have to be copied explicitly to ensure
+            % e.g. this.OBJECT = copy(obj.OBJECT)
+        end
     end
 end

--- a/Doc/source/abstract.rst
+++ b/Doc/source/abstract.rst
@@ -12,7 +12,7 @@ Map
 .. autoclass:: Map
     :show-inheritance:
     :members: apply, applyJacobianT, applyInverse, makeComposition, plus, minus, mpower, times,
-      mtimes, size, apply_, applyJacobianT_, applyInverse_, plus_, minus_, mpower_, makeComposition_, times_
+      mtimes, size, apply_, applyJacobianT_, applyInverse_, plus_, minus_, mpower_, makeComposition_, times_,copyElement
 
 LinOp
 -----

--- a/Doc/source/infos.rst
+++ b/Doc/source/infos.rst
@@ -303,7 +303,7 @@ Deep Copy
 
 By default matlab performs shallow copy of handle objects such as :class:`Map` and inherited classes.
 It means that shallow copied object will share the same properties and memoize system cache during their whole life. 
-The function :meth:`copy` perform a deep copy preventing this sharing. Its behaviour can be changed by overloading the 
+The function :meth:`copy` perform a deep copy preventing this sharing. Its behavior can be changed by overloading the 
 method :meth:`copyElement`.
 
 .. code:: matlab

--- a/Doc/source/infos.rst
+++ b/Doc/source/infos.rst
@@ -298,6 +298,45 @@ which is semi-orthogonal (its :meth:`makeHHt_` returns a :class:`LinOpDiag` with
 a new object and may slow iterative algorithms. However, it can be
 used freely in constructor methods or in other methods as a default implementation.
 
+Deep Copy
+----------------------------------
+
+By default matlab performs shallow copy of handle objects such as :class:`Map` and inherited classes.
+It means that shallow copied object will share the same properties and memoize system cache during their whole life. 
+The function :meth:`copy` perform a deep copy preventing this sharing. Its behaviour can be changed by overloading the 
+method :meth:`copyElement`.
+
+.. code:: matlab
+
+    >> H=LinOpConv(fftn(psf));
+    >> H.memoizeOpts.apply=true;       % Activate the memoize cache
+    >> tic; y =H*x;toc
+    Elapsed time is 2.117364 seconds.
+    >> tic; y =H*x;toc                  
+    Elapsed time is 0.090888 seconds.
+    >> B = H;                           % Shallow copy
+    >> tic; y =B*x;                     % H and B share the same memoize cache 
+    Elapsed time is 0.089999 seconds.   
+    >> tic; y =B*z;toc  
+    Elapsed time is 2.250312 seconds.
+    >> tic; y =H*x;toc                  
+    Elapsed time is 2.180036 seconds.
+
+using :meth:`copy` deep copy:
+
+.. code:: matlab
+
+    >> C = copy(H)                     % Deep Copy
+    >> tic; y =H*x;toc
+    Elapsed time is 2.117364 seconds.
+    >> tic; y =H*x;toc                  
+    Elapsed time is 0.090888 seconds.
+    >> tic; y =C*x;toc
+    Elapsed time is 2.202259 seconds.
+    >> tic; y =C*z;toc
+    Elapsed time is 2.194160 seconds.
+    >> tic; y =H*x;toc
+    Elapsed time is 0.097449 seconds.
 
 Auxiliary Utilities
 -------------------

--- a/LinOp/TemplateLinOp.m
+++ b/LinOp/TemplateLinOp.m
@@ -83,5 +83,12 @@ classdef TemplateLinOp <  LinOp
 		
         % TODO : IMPLEMENT ANY USEFUL METHOD FROM INHERITED FROM MAP OR
         % LINOP CLASSES
+        
+        %% Deep copy: IMPLEMENT IF APPLICABLE
+        function this = copyElement(obj)
+            this = copyElement@LinOp(obj);
+            % properties that are handle objects such as Map have to be copied explicitly to ensure
+            % e.g. this.OBJECT = copy(obj.OBJECT)
+        end
     end
 end

--- a/Opti/OutputOpti/OutputOpti.m
+++ b/Opti/OutputOpti/OutputOpti.m
@@ -1,4 +1,4 @@
-classdef OutputOpti < handle
+classdef OutputOpti < matlab.mixin.Copyable
     % OutputOpti class for algorithms displayings and savings
     %
     % At each :attr:`ItUpOut` iterations of an optimization algorithm (see :class:`Opti` generic class),
@@ -186,5 +186,12 @@ classdef OutputOpti < handle
             reconstruction = this.snrOp.apply(opti.xopt);
             snr=20*log10(this.normXtrue/norm(this.xtrue(:)-reconstruction(:)));
         end
+    end
+    methods (Access = protected)
+        %% Copy
+      function this = copyElement(obj)
+          this = copyElement@matlab.mixin.Copyable(obj);
+          this.snrOp = copyElement@Map(obj.snrOp);
+      end
     end
 end

--- a/Opti/TestCvg/TestCvg.m
+++ b/Opti/TestCvg/TestCvg.m
@@ -1,4 +1,4 @@
-classdef TestCvg  < handle
+classdef TestCvg  < matlab.mixin.Copyable
     % TestCvg class  monitor convergence criterion during optimization
     %
     % At each iterations of an optimization algorithm (see :class:`Opti` generic class),

--- a/Opti/TestCvg/TestCvgCombine.m
+++ b/Opti/TestCvg/TestCvgCombine.m
@@ -61,5 +61,15 @@ classdef TestCvgCombine < TestCvg
             end
         end
     end
+    
+    methods (Access = protected)
+        %% Copy
+      function cpObj = copyElement(obj)
+          cpObj = copyElement@TestCvg(obj);
+            for n=1:obj.testNumber
+                cpObj.cvList{n} = copyElement@TestCvg(obj.cvList{n});
+            end
+      end
+    end
 end
 

--- a/Opti/TestCvg/TestCvgCostAbsolute.m
+++ b/Opti/TestCvg/TestCvgCostAbsolute.m
@@ -36,7 +36,7 @@ classdef TestCvgCostAbsolute  < TestCvg
             assert(isscalar(costAbsoluteTol),'costAbsoluteTol must be scalar');
             this.costAbsoluteTol =costAbsoluteTol;
             if(nargin==2)
-                assert(isscalar(costIndex),'costIndex must be a scalar integer');
+                % assert(isscalar(costIndex),'costIndex must be a scalar integer');
                 this.costIndex = costIndex;
             end
         end

--- a/Opti/TestCvg/TestCvgCostRelative.m
+++ b/Opti/TestCvg/TestCvgCostRelative.m
@@ -26,10 +26,10 @@ classdef TestCvgCostRelative  < TestCvg
     
     properties (SetAccess = public,GetAccess = public)
         costRelativeTol=1e-5;      % stopping criteria tolerance on the relative difference btw two successive iterates
-        costIndex=0;              % index of the cost function
     end
     properties (SetAccess = protected,GetAccess = protected)
         oldCost=[];
+        costIndex=0;              % index of the cost function
     end
     methods
         %% Constructor


### PR DESCRIPTION
By default matlab performs shallow copy of handle objects such `Map` and inherited classes. It means that shallow copied object will share the same properties and memoize system cache during their whole life. The function `copy` perform a deep copy preventing this sharing. Its behavior can be changed by overloading the method `copyElement`.

    >> H=LinOpConv(fftn(psf));
    >> H.memoizeOpts.apply=true;       % Activate the memoize cache
    >> tic; y =H*x;toc
    Elapsed time is 2.117364 seconds.
    >> tic; y =H*x;toc                  
    Elapsed time is 0.090888 seconds.
    >> B = H;                           % Shallow copy
    >> tic; y =B*x;                     % H and B share the same memoize cache 
    Elapsed time is 0.089999 seconds.   
    >> tic; y =B*z;toc  
    Elapsed time is 2.250312 seconds.
    >> tic; y =H*x;toc                  
    Elapsed time is 2.180036 seconds.

using `copy` deep copy 

    >> C = copy(H)                     % Deep Copy
    >> tic; y =H*x;toc
    Elapsed time is 2.117364 seconds.
    >> tic; y =H*x;toc                  
    Elapsed time is 0.090888 seconds.
    >> tic; y =C*x;toc
    Elapsed time is 2.202259 seconds.
    >> tic; y =C*z;toc
    Elapsed time is 2.194160 seconds.
    >> tic; y =H*x;toc
    Elapsed time is 0.097449 seconds.
