### PR TITLE
[FIX] StackMap Adjoint with Trailing Singleton Dimensions

### DIFF
--- a/Abstract/OperationsOnMaps/StackMap.m
+++ b/Abstract/OperationsOnMaps/StackMap.m
@@ -97,8 +97,8 @@ classdef StackMap < Map
 
         function x = applyJacobianT_(this, y, v)
             % Reimplemented from :class:`Map`
-            full_dim = size(y);
-            plain_dim = full_dim(1:end - 1);
+            full_dim = this.sizeout;
+            plain_dim = this.mapsCell{1}.sizeout;
             cat_dim = full_dim(end);
             y_flattened = reshape(y, [], cat_dim);
             x = cell(this.numMaps,1);


### PR DESCRIPTION
 - Fixes subtle bug in the adjoint calculation of StackMap, introduced with
   PR #27. It occurs when using a StackMap wrapping a single operator.
 - For > 2-D arrays, Matlab implicitly squeezes trailing singleton dimensions.
   Consequently, slicing in the last dimension of the size vector as returned
   by size(data) happens in the last non-singleton dimension, not along the
   last dimension of the full size.
 - Example: size(ones(5, 4, 3, 1, 1)) --> [5, 4, 3] --> ones(sizevec(1:end-1))
   --> 5x4, not 5x4x3x1.
 - Subsequently, the adjoint calculation fails with incompatible sizes.
 - Solution: simply query sizes from the operators directly, where squeezing
   does not take place.