### PR TITLE
Save memory

### DIFF
--- a/Abstract/Opti.m
+++ b/Abstract/Opti.m
@@ -43,7 +43,8 @@ classdef Opti < matlab.mixin.SetGet
         time;                % running time of the algorithm (last run)
         niter;               % iteration counter
         xopt=[];             % optimization variable
-        xold;
+        xold=[];
+        needxold=false;
     end
     % Full public properties
     properties
@@ -89,7 +90,9 @@ classdef Opti < matlab.mixin.SetGet
                     if this.ItUpOut>0 && (((mod(this.niter,this.ItUpOut)==0)|| (this.niter==1)))
                         this.OutOp.update(this);
                     end
-                    this.xold=this.xopt;
+                    if this.needxold
+                        this.xold=this.xopt;
+                    end
                 elseif  flag==this.OPTI_STOP,
                     break;
                 end
@@ -104,7 +107,12 @@ classdef Opti < matlab.mixin.SetGet
             
             if ~isempty(x0) % To restart from current state if wanted
                 this.xopt=x0;
-                this.xold= x0;
+                if this.CvOp.needxold
+                    this.needxold=true;
+                end
+                if this.needxold
+                    this.xold=x0;
+                end
             end
         end
         function flag=doIteration(this)

--- a/Example/DeconvEx/2D/Deconv_LS_TV_NonNeg.m
+++ b/Example/DeconvEx/2D/Deconv_LS_TV_NonNeg.m
@@ -64,7 +64,7 @@ rho_n=[1e-1,1e-1];
 ADMM=OptiADMM(F,Fn,Hn,rho_n);
 ADMM.OutOp=OutputOptiSNR(1,im,10,[1 2]);
 % STOP when the sum successives C = F*x + Fn{1}*Hn{1}*x is lower than 1e-4 or when the distance between two successive step is lower than 1e-5
-ADMM.CvOp=TestCvgCombine(TestCvgCostRelative(1e-4,[1 2]), 'StepRelative',1e-4);  
+ADMM.CvOp=TestCvgCombine(TestCvgCostRelative(1e-4,[1 2]), 'StepRelative',1e-4,TestCvgADMM());  
 ADMM.ItUpOut=2;             % call OutputOpti update every ItUpOut iterations
 ADMM.maxiter=200;           % max number of iterations
 ADMM.run(y);   % run the algorithm 

--- a/Opti/OptiADMM.m
+++ b/Opti/OptiADMM.m
@@ -218,8 +218,11 @@ classdef OptiADMM < Opti
                     this.xopt=this.CG.xopt;
                 end
             else
-                zn = this.yn{n}+this.wn{n};
+                for n=1:length(this.Fn)
+                    zn{n} = this.yn{n}+this.wn{n};
+                end
                 this.xopt=this.solver(zn,this.rho_n, this.xopt);
+                clear zn;
             end
             for n=1:length(this.wn)
                 this.Hnx{n}=this.Hn{n}.apply(this.xopt);

--- a/Opti/OptiADMM.m
+++ b/Opti/OptiADMM.m
@@ -54,7 +54,7 @@ classdef OptiADMM < Opti
     %     along with this program.  If not, see <http://www.gnu.org/licenses/>.
     
     % Protected Set and public Read properties
-    properties (SetAccess = protected,GetAccess = public)
+    properties (SetAccess = public,GetAccess = public)
         F0=[];               % func F0
         Fn;                  % Cell containing the Cost Fn
         Hn;                  % Cell containing the LinOp Hn
@@ -66,11 +66,9 @@ classdef OptiADMM < Opti
     %?TestCvg})  % This makes problems for doc compilation. For the moment
     %I let all the attributes public
         yn;    % Internal parameters
-        zn;
         wn;
         Hnx;
         b0=0;
-        yold=0;  % Parameter needed for termination criterion
         
         
         % To manage the new maxiterCG property of ADMM (from v1.1.2)
@@ -201,15 +199,13 @@ classdef OptiADMM < Opti
         end
         function flag=doIteration(this)
             % Reimplementation from :class:`Opti`. For details see [1].
-            this.yold = this.yn;
             for n=1:length(this.Fn)
                 this.yn{n}=this.Fn{n}.applyProx(this.Hnx{n} - this.wn{n},1/this.rho_n(n));
-                this.zn{n}=this.yn{n}+this.wn{n};
             end
             if isempty(this.solver)
-                b=this.rho_n(1)*this.Hn{1}.applyAdjoint(this.zn{1});
+                b=this.rho_n(1)*this.Hn{1}.applyAdjoint(this.yn{1}+this.wn{1});
                 for n=2:length(this.Hn)
-                    b=b+this.rho_n(n)*this.Hn{n}.applyAdjoint(this.zn{n});
+                    b=b+this.rho_n(n)*this.Hn{n}.applyAdjoint(this.yn{n}+this.wn{n});
                 end
                 if ~isempty(this.b0)
                     b=b+this.b0;
@@ -222,7 +218,8 @@ classdef OptiADMM < Opti
                     this.xopt=this.CG.xopt;
                 end
             else
-                this.xopt=this.solver(this.zn,this.rho_n, this.xopt);
+                zn = this.yn{n}+this.wn{n};
+                this.xopt=this.solver(zn,this.rho_n, this.xopt);
             end
             for n=1:length(this.wn)
                 this.Hnx{n}=this.Hn{n}.apply(this.xopt);

--- a/Opti/OptiChambPock.m
+++ b/Opti/OptiChambPock.m
@@ -98,7 +98,7 @@ classdef OptiChambPock < Opti
     		this.F=F;
     		this.G=G;
             this.H=H;
-            
+            this.needxold =true;
             if this.H.norm>=0
                 this.sig=1/(this.tau*this.H.norm^2)-eps;
             end

--- a/Opti/OptiFBS.m
+++ b/Opti/OptiFBS.m
@@ -78,6 +78,7 @@ classdef OptiFBS < Opti
             this.cost=F+G;
             this.F=F;
             this.G=G;
+            this.needxold = true;
             if F.lip~=-1
                 this.gam=1/F.lip;
             end

--- a/Opti/OptiGradDsct.m
+++ b/Opti/OptiGradDsct.m
@@ -58,6 +58,8 @@ classdef OptiGradDsct < Opti
             
             initialize@Opti(this,x0);
             if this.nagd
+                this.needxold = true;
+                this.xold = x0;
                 this.y=x0;
             end
             if isempty(this.gam), error('Parameter gam is not setted'); end

--- a/Opti/OptiPrimalDualCondat.m
+++ b/Opti/OptiPrimalDualCondat.m
@@ -77,6 +77,7 @@ classdef OptiPrimalDualCondat < Opti
             this.Hn=Hn;
             this.F0=F0;
             this.G=G;
+            this.needxold = true;
             if ~isempty(F0), this.cost=F0;end
             if ~isempty(G)
                 if isempty(this.cost), this.cost=G;
@@ -128,7 +129,8 @@ classdef OptiPrimalDualCondat < Opti
             for n=1:length(this.Fn)
                 ytilde=this.Fn{n}.applyProxFench(this.y{n}+this.sig*this.Hn{n}.apply(2*xtilde-this.xold),this.sig);
                 this.y{n}=this.rho*ytilde +(1-this.rho)*this.y{n};
-            end            
+            end  
+
             flag=this.OPTI_NEXT_IT;
         end
     end

--- a/Opti/TestCvg/TestCvg.m
+++ b/Opti/TestCvg/TestCvg.m
@@ -31,6 +31,7 @@ classdef TestCvg  < matlab.mixin.Copyable
     
     properties (SetAccess = protected,GetAccess = public)
         name = 'TestCvg';
+        needxold = false;
     end
     
     methods

--- a/Opti/TestCvg/TestCvgADMM.m
+++ b/Opti/TestCvg/TestCvgADMM.m
@@ -15,7 +15,7 @@ classdef TestCvgADMM < TestCvg
     %
     % **Example** CvOpti=TestCvgADMM(eps_abs,eps_rel)
     %
-    % See also :class:`TestCvg`FBS.CvOp=TestCvgCombine(TestCvgCostRelative(1e-4), 'StepRelative',1e-4);  
+    % See also :class:`TestCvg`
 
     
     %%    Copyright (C) 2018

--- a/Opti/TestCvg/TestCvgCombine.m
+++ b/Opti/TestCvg/TestCvgCombine.m
@@ -49,6 +49,7 @@ classdef TestCvgCombine < TestCvg
                     this.cvList = {this.cvList, varargin{n}.cvList };
                     this.testNumber = this.testNumber + varargin{n}.testNumber;
                 end
+                this.needxold = this.needxold || this.cvList{this.testNumber}.needxold;
             end
         end
         %% Update method

--- a/Opti/TestCvg/TestCvgStepRelative.m
+++ b/Opti/TestCvg/TestCvgStepRelative.m
@@ -33,6 +33,7 @@ classdef TestCvgStepRelative  < TestCvg
             this.name = 'TestCvgStepRelative';
             assert(isscalar(stepRelativeTol),'stepRelativeTol must be scalar');
             this.stepRelativeTol =stepRelativeTol;
+            this.needxold = true;
         end
         %% Update method
         function stop = testConvergence(this,opti)


### PR DESCRIPTION
Do a few things to improve the memory footprint of optimization methods:
- previous iterate `xold` is no longer stored when it is not necessary 
- remove some temporary variable in ADMM