### PR TITLE
Fix l2 prox for schatten (used to be prox of squared l2)

### DIFF
--- a/Cost/CostMixNormSchatt1.m
+++ b/Cost/CostMixNormSchatt1.m
@@ -108,10 +108,11 @@ classdef CostMixNormSchatt1 < Cost
                 E=max(abs(E)-alpha,0).*sign(E);
                 y=reshape(this.svdRecomp(E,V),this.sizein);
             elseif this.p==2
+                dim=floor(sqrt(2*size(x)(end)));
                 diag_inds=cumsum(dim+1:-1:2)-dim;
                 x2=x.^2;
                 Frob=sqrt(2*sum(x2,3) - sum(x2(:,:,diag_inds),3));
-                y=max(1-1./Frob,0).*x;
+                y=max(1-alpha./Frob,0).*x;
             else
                 y=applyProx_@Cost(this,x,alpha);
             end

--- a/Cost/CostMixNormSchatt1.m
+++ b/Cost/CostMixNormSchatt1.m
@@ -108,8 +108,10 @@ classdef CostMixNormSchatt1 < Cost
                 E=max(abs(E)-alpha,0).*sign(E);
                 y=reshape(this.svdRecomp(E,V),this.sizein);
             elseif this.p==2
-                Frob = sqrt(sum(x.^2,3)+x(:,:,2).^2);
-                y = max(1-1./Frob,0).*x;
+                diag_inds=cumsum(dim+1:-1:2)-dim;
+                x2=x.^2;
+                Frob=sqrt(2*sum(x2,3) - sum(x2(:,:,diag_inds),3));
+                y=max(1-1./Frob,0).*x;
             else
                 y=applyProx_@Cost(this,x,alpha);
             end

--- a/Cost/CostMixNormSchatt1.m
+++ b/Cost/CostMixNormSchatt1.m
@@ -108,9 +108,8 @@ classdef CostMixNormSchatt1 < Cost
                 E=max(abs(E)-alpha,0).*sign(E);
                 y=reshape(this.svdRecomp(E,V),this.sizein);
             elseif this.p==2
-                [E,V]=this.svdDecomp(x);
-                E=E./(1+alpha);
-                y=reshape(this.svdRecomp(E,V),this.sizein);
+                Frob = sqrt(sum(x.^2,3)+x(:,:,2).^2);
+                y = max(1-1./Frob,0).*x;
             else
                 y=applyProx_@Cost(this,x,alpha);
             end


### PR DESCRIPTION
Would like to thank Thomas Debarre and Emmanuel Soubies for discussion.
Either replace 
    E=E./(1+alpha);
for
         E=max(1-alpha./sqrt(sum(E.^2,3)),0);
         E=bsxfun(@times, E, pE)
or notice that schatten-2 is the Frobenius norm, i.e. no need for svds.